### PR TITLE
👽️ Add "table" and "table_row" types to Block

### DIFF
--- a/src/response/block.ts
+++ b/src/response/block.ts
@@ -12,28 +12,16 @@ interface Caption {
 }
 interface Blocks {
     paragraph: Text
+    heading_1: Text
+    heading_2: Text
+    heading_3: Text
     bulleted_list_item: Text
     numbered_list_item: Text
-    toggle: Text
     to_do: Text & {
         /** Whether the to_do is checked or not. */
         checked: boolean | null
     }
-    quote: Text
-    callout: Text & {
-        /** Page icon. */
-        icon: Emoji | File
-    }
-    synced_block: {
-        synced_from: null | {
-            /** Type of this synced from object.  */
-            type: 'block_id'
-            /** Identifier of an original synced_block */
-            block_id: string
-        }
-    }
-    template: Text
-    column: Record<string, never>
+    toggle: Text
     child_page: {
         /** Plain text of page title. */
         title: string
@@ -42,9 +30,6 @@ interface Blocks {
         /** Plain text of the database title */
         title: string
     }
-    heading_1: Text
-    heading_2: Text
-    heading_3: Text
     embed: Caption & {
         /** Link to website the embed block will display. */
         url: string
@@ -57,12 +42,27 @@ interface Blocks {
         /** Bookmark link */
         url: string
     }
+    callout: Text & {
+        /** Page icon. */
+        icon: Emoji | File
+    }
+    quote: Text
     equation: { /** A KaTeX compatible string */ expression: string }
     divider: Record<string, never>
     table_of_contents: Record<string, never>
     breadcrumb: Record<string, never>
+    column: Record<string, never>
     column_list: Record<string, never>
     link_preview: { url: string }
+    synced_block: {
+        synced_from: null | {
+            /** Type of this synced from object.  */
+            type: 'block_id'
+            /** Identifier of an original synced_block */
+            block_id: string
+        }
+    }
+    template: Text
     link_to_page:
         | { type: 'page_id'; page_id: string }
         | { type: 'database_id'; database_id: string }

--- a/src/response/block.ts
+++ b/src/response/block.ts
@@ -66,6 +66,18 @@ interface Blocks {
     link_to_page:
         | { type: 'page_id'; page_id: string }
         | { type: 'database_id'; database_id: string }
+    table: {
+        /** Number of columns in the table. */
+        readonly table_width: number
+        /** Whether or not the table has a column header. If `true`, the first row in the table will appear visually distinct from the other rows. */
+        has_column_header: boolean
+        /** Whether or not the table has a header row. If true, the first column in the table will appear visually distinct from the other columns. */
+        has_row_header: boolean
+    }
+    table_row: {
+        /** Array of cell contents in horizontal display order. Array length should match the `"table_width"` value of the table containing this row. Each cell itself is an array of rich text objects. */
+        cells: RichText[][]
+    }
     unsupported: Record<string, never>
 }
 export type BlockType = keyof Blocks


### PR DESCRIPTION
# Description
The Notion API added [simple table support](https://developers.notion.com/changelog/simple-table-support). This change will add `"table"` and `"table_row"`to the Blocks interface, therefore including it in the `Block` export.

## Type of Change

- [x] New feature (adds new functionality)

## Checklist

- [x] My commits are clear and use [gitmoji](https://github.com/carloscuesta/gitmoji).
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
