### PR TITLE
Implement changes from Notion API release 2022-02-22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 dist
 types
-
-# eslint
+node_modules
 .eslintcache

--- a/src/endpoints/blocks/update.ts
+++ b/src/endpoints/blocks/update.ts
@@ -5,7 +5,7 @@ import { Resolve } from '../../utils'
 export interface Request extends RequestTemplate {
     endpoint: `blocks/${string}`
     method: 'PATCH'
-    params?: UpdateType<'text' | 'checked'> & {
+    params?: UpdateType<'rich_text' | 'checked'> & {
         /** Set to true to archive (delete) a block. Set to false to un-archive (restore) a block. */
         archived?: boolean
     }

--- a/src/endpoints/databases/filter/conditions.ts
+++ b/src/endpoints/databases/filter/conditions.ts
@@ -105,7 +105,7 @@ export interface Relation extends Empty {
 /** A formula filter condition applies to database properties of type `"formula"`. */
 export interface Formula {
     /** Only return pages where the result type of the page property formula is "text" and the provided text filter condition matches the formula's value. */
-    text: Text
+    string: Text
     /** Only return pages where the result type of the page property formula is "checkbox" and the provided checkbox filter condition matches the formula's value. */
     checkbox: Checkbox
     /** Only return pages where the result type of the page property formula is "number" and the provided number filter condition matches the formula's value. */

--- a/src/endpoints/pages/index.ts
+++ b/src/endpoints/pages/index.ts
@@ -1,3 +1,4 @@
 export * as Retrieve from './retrieve'
 export * as Create from './create'
 export * as Update from './update'
+export * as Properties from './properties'

--- a/src/endpoints/pages/properties/index.ts
+++ b/src/endpoints/pages/properties/index.ts
@@ -1,0 +1,1 @@
+export * as Retrieve from './retrieve'

--- a/src/endpoints/pages/properties/retrieve.ts
+++ b/src/endpoints/pages/properties/retrieve.ts
@@ -1,0 +1,36 @@
+import { RequestTemplate, List } from '../../global'
+import { NotionResponse } from '../../..'
+
+export interface Request extends RequestTemplate {
+    endpoint: `pages/${string}/properties/${string}`
+    method: 'GET'
+    params?: {
+        /** For paginated properties. */
+        start_cursor?: string
+        /** For paginated properties. The max number of property item objects on a page. The default size is 100 */
+        page_size?: number
+    }
+}
+
+/** Note: Missing Rollup type */
+export type Response =
+    | Exclude<PropertyItem, { type: ComplexResponseTypes | 'rollup' }>
+    | PaginatedPropertyValues<
+          Extract<PropertyItem, { type: ComplexResponseTypes }>
+      >
+    | PaginatedPropertyValues<NotionResponse.PageProperties.Relation>
+
+type ComplexResponseTypes = 'title' | 'rich_text' | 'relation' | 'people'
+
+type PropertyItem = NotionResponse.PageProperty & { object: 'property_item' }
+
+type PaginatedPropertyValues<T extends { type: string }> = {
+    [K in T as K['type']]: List<T> & {
+        type: 'property_item'
+        property_item: {
+            id: string
+            next_url: string | null
+            type: K['type']
+        } & { [_ in K['type']]: Record<never, never> }
+    }
+}[T['type']]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export type Version = '2020-02-22'
 export * as NotionResponse from './responses'
 export * as NotionRequest from './requests'
 export * as Endpoints from './endpoints'

--- a/src/requests/blocks.ts
+++ b/src/requests/blocks.ts
@@ -9,7 +9,7 @@ interface BlockBase {
 
 interface Text {
     /** Rich text in the block. */
-    text: NotionRequest.RichText[]
+    rich_text: NotionRequest.RichText[]
 }
 interface Caption {
     /** Caption of the block */

--- a/src/responses/blocks.ts
+++ b/src/responses/blocks.ts
@@ -23,7 +23,7 @@ interface ChildlessBase extends BlockBase {
 
 interface Text {
     /** Rich text in the block. */
-    text: NotionResponse.RichText[]
+    rich_text: NotionResponse.RichText[]
 }
 interface Caption {
     /** Caption of the block */

--- a/tests/requests/blocks.test.ts
+++ b/tests/requests/blocks.test.ts
@@ -2,32 +2,38 @@ import type { Blocks, Block } from '../../types/requests'
 import { anyRichText, anyFile } from '.'
 import { index, AllUnionUsed } from '../utils'
 
-export const text: Blocks.Heading1['heading_1']['text'] = [anyRichText]
+export const rich_text: Blocks.Heading1['heading_1']['rich_text'] = [
+    anyRichText,
+]
 export const caption: Blocks.Image['image']['caption'] = [anyRichText]
-export const children: Block[] = [{ paragraph: { text } }]
+export const children: Block[] = [{ paragraph: { rich_text } }]
 
-export const paragraph: Blocks.Paragraph = { paragraph: { text, children } }
+export const paragraph: Blocks.Paragraph = {
+    paragraph: { rich_text, children },
+}
 
-export const heading1: Blocks.Heading1 = { heading_1: { text, children } }
+export const heading1: Blocks.Heading1 = { heading_1: { rich_text, children } }
 
-export const heading2: Blocks.Heading2 = { heading_2: { text, children } }
+export const heading2: Blocks.Heading2 = { heading_2: { rich_text, children } }
 
-export const heading3: Blocks.Heading3 = { heading_3: { text, children } }
+export const heading3: Blocks.Heading3 = { heading_3: { rich_text, children } }
 
 export const bulletedListItem: Blocks.BulletedListItem = {
-    bulleted_list_item: { text, children },
+    bulleted_list_item: { rich_text, children },
 }
 
 export const numberedListItem: Blocks.NumberedListItem = {
-    numbered_list_item: { text, children },
+    numbered_list_item: { rich_text, children },
 }
 
-export const toDo: Blocks.ToDo = { to_do: { text, checked: true, children } }
+export const toDo: Blocks.ToDo = {
+    to_do: { rich_text, checked: true, children },
+}
 
-export const toggle: Blocks.Toggle = { toggle: { text, children } }
+export const toggle: Blocks.Toggle = { toggle: { rich_text, children } }
 
 export const code: Blocks.Code = {
-    code: { text, caption, language: 'typescript' },
+    code: { rich_text, caption, language: 'typescript' },
 }
 
 export const embed: Blocks.Embed = {
@@ -46,9 +52,9 @@ export const bookmark: Blocks.Bookmark = {
     bookmark: { url: 'http://localhost:5050', caption },
 }
 
-export const callout: Blocks.Callout = { callout: { text, children } }
+export const callout: Blocks.Callout = { callout: { rich_text, children } }
 
-export const quote: Blocks.Quote = { quote: { text, children } }
+export const quote: Blocks.Quote = { quote: { rich_text, children } }
 
 export const equation: Blocks.Equation = { equation: { expression: 'e=mc^2' } }
 
@@ -70,7 +76,7 @@ export const syncedBlock: Blocks.SyncedBlock = {
     },
 }
 
-export const template: Blocks.Template = { template: { text, children } }
+export const template: Blocks.Template = { template: { rich_text, children } }
 
 export const linkToPage: Blocks.LinkToPage = {
     link_to_page: [
@@ -79,7 +85,7 @@ export const linkToPage: Blocks.LinkToPage = {
     ][index],
 }
 
-export const tableRow: Blocks.TableRow = { table_row: { cells: [text] } }
+export const tableRow: Blocks.TableRow = { table_row: { cells: [rich_text] } }
 
 export const table: Blocks.Table = {
     table: { table_width: 2, children: [tableRow, tableRow] },

--- a/tests/responses/blocks.test.ts
+++ b/tests/responses/blocks.test.ts
@@ -16,66 +16,66 @@ const childlessBase: Omit<Blocks.Bookmark, 'type' | 'bookmark'> = {
     has_children: false,
 }
 
-const text: Blocks.Heading1['heading_1']['text'] = [anyRichText]
+const rich_text: Blocks.Heading1['heading_1']['rich_text'] = [anyRichText]
 const caption: Blocks.Image['image']['caption'] = [anyRichText]
 
 const paragraph: Blocks.Paragraph = {
     ...blockBase,
-    paragraph: { text },
+    paragraph: { rich_text },
     type: 'paragraph',
 }
 
 const heading1: Blocks.Heading1 = {
     ...blockBase,
-    heading_1: { text },
+    heading_1: { rich_text },
     type: 'heading_1',
 }
 
 const heading2: Blocks.Heading2 = {
     ...blockBase,
-    heading_2: { text },
+    heading_2: { rich_text },
     type: 'heading_2',
 }
 
 const heading3: Blocks.Heading3 = {
     ...blockBase,
-    heading_3: { text },
+    heading_3: { rich_text },
     type: 'heading_3',
 }
 
 const bulletedListItem: Blocks.BulletedListItem = {
     ...blockBase,
-    bulleted_list_item: { text },
+    bulleted_list_item: { rich_text },
     type: 'bulleted_list_item',
 }
 
 const numberedListItem: Blocks.NumberedListItem = {
     ...blockBase,
-    numbered_list_item: { text },
+    numbered_list_item: { rich_text },
     type: 'numbered_list_item',
 }
 
 const toDo: Blocks.ToDo = {
     ...blockBase,
-    to_do: { checked: true, text },
+    to_do: { checked: true, rich_text },
     type: 'to_do',
 }
 
 const toggle: Blocks.Toggle = {
     ...blockBase,
-    toggle: { text },
+    toggle: { rich_text },
     type: 'toggle',
 }
 
 const code: Blocks.Code = {
     ...childlessBase,
-    code: { text, caption, language: 'typescript' },
+    code: { rich_text, caption, language: 'typescript' },
     type: 'code',
 }
 
 const bulletedListItem1: Blocks.BulletedListItem = {
     ...blockBase,
-    bulleted_list_item: { text },
+    bulleted_list_item: { rich_text },
     type: 'bulleted_list_item',
 }
 
@@ -129,13 +129,13 @@ const pdf: Blocks.Pdf = {
 
 const callout: Blocks.Callout = {
     ...blockBase,
-    callout: { icon: emoji, text },
+    callout: { icon: emoji, rich_text },
     type: 'callout',
 }
 
 const quote: Blocks.Quote = {
     ...blockBase,
-    quote: { text },
+    quote: { rich_text },
     type: 'quote',
 }
 
@@ -191,7 +191,7 @@ const syncedBlock: Blocks.SyncedBlock = {
 
 const template: Blocks.Template = {
     ...blockBase,
-    template: { text },
+    template: { rich_text },
     type: 'template',
 }
 


### PR DESCRIPTION
## Notion Version 2022-02-22 Changes

- [x] `text` in blocks has been renamed to `rich_text`.
- [x] Query database filter changes:
  - [x] `phone` and `text` are no longer supported in query database filters when filtering by `phone_number` and `rich_text` properties. Use `phone_number` and `rich_text` instead.
  - [ ] `rollup` query database filters no longer accept the `text` keyword. Use `rich_text` instead.
  - [x] `formula` query database filters no longer accept the `text` keyword. Use `string` instead.
- [x] `property_item` objects now return a `type`, `next_url`, and `id`.
- [ ] Deprecated the List Databases API endpoint

Changes come from a [post on the Notion Changelog](https://developers.notion.com/changelog/releasing-notion-version-2022-02-22).
